### PR TITLE
Detect at runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ build: $(OBJECTS) $(HEADERS)
 $(OBJ_DIR)/%_c.o: %.c
 	@echo "==>" compiling $<
 	@mkdir -p $(@D)
-	$(ARMGNU)-gcc -D $(PLATFORM) $(CFLAGS) $(INCLUDES) -c $< -o $@
+	$(ARMGNU)-gcc $(CFLAGS) $(INCLUDES) -c $< -o $@
 
 $(OBJ_DIR)/%_s.o: %.S
 	@echo "==>" building $<

--- a/src/common/utils.S
+++ b/src/common/utils.S
@@ -1,3 +1,8 @@
+.globl get_core_info
+get_core_info:
+	mrs x0, midr_el1
+	ret
+
 .globl get_core_id
 get_core_id:
 	mrs x0, mpidr_el1

--- a/src/common/utils.c
+++ b/src/common/utils.c
@@ -1,0 +1,12 @@
+#include "utils.h"
+
+int get_raspi_ver (void) {
+	unsigned int cpu_id = get_core_info();
+	if (cpu_id == 0x410FD034) {
+		return RASPI3;   // raspi2 & 3
+	} else if (cpu_id == 0x410FD083) {
+		return RASPI4;   // raspi4
+	} else {
+		return 0;// Unknown
+	}
+}

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -4,11 +4,19 @@
 
 #ifndef __ASSEMBLER__
 
+extern unsigned int get_core_info ( void );
 extern unsigned int get_core_id ( void );
 extern void put32 ( unsigned long, unsigned int);
 extern unsigned int get32 ( unsigned long );
 extern void delay ( unsigned long );
 
 #endif
+
+enum {
+	RASPI3 = 3,
+	RASPI4 = 4,
+};
+
+int get_raspi_ver ( void );
 
 #endif  /*_UTILS_H */

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -1,4 +1,5 @@
 #include "../peripherals/uart.h"
+#include "../common/utils.h"
 
 static unsigned int current_processor_index = 0;
 
@@ -7,6 +8,19 @@ void kernel_main(unsigned long processor_index)
 
 	if (processor_index == 0) {
 		uart_init();
+
+		switch (get_raspi_ver()) {
+			case RASPI3:
+				uart_send_string("We're a raspi3\r\n");
+				break;
+
+			case RASPI4:
+				uart_send_string("We're a raspi4\r\n");
+				break;
+
+			default:
+				uart_send_string("I don't know what we are!?!?!?\r\n");
+		}
 	}
 
 	while (processor_index != current_processor_index) { }

--- a/src/peripherals/uart.c
+++ b/src/peripherals/uart.c
@@ -3,6 +3,48 @@
 
 void uart_init (void)
 {
+	switch (get_raspi_ver()) {
+		case RASPI3:
+			GPIO_BASE = 0x3f200000;   // raspi2 & 3
+			break;
+
+		case RASPI4:
+			GPIO_BASE = 0xFE200000;   // raspi4
+			break;
+
+		default:
+			return;
+			// die?
+	}
+
+	// GPIO
+	GPFSEL1		= (GPIO_BASE + 0x04);
+	GPSET0		= (GPIO_BASE + 0x1C);
+	GPCLR0		= (GPIO_BASE + 0x28);
+	GPPUD		= (GPIO_BASE + 0x94);
+	GPPUDCLK0	= (GPIO_BASE + 0x98);
+
+	// The base address for UART.
+	UART0_BASE   = (GPIO_BASE + 0x1000);
+	UART0_DR     = (UART0_BASE + 0x00);
+	UART0_RSRECR = (UART0_BASE + 0x04);
+	UART0_FR     = (UART0_BASE + 0x18);
+    UART0_ILPR   = (UART0_BASE + 0x20);
+    UART0_IBRD   = (UART0_BASE + 0x24);
+    UART0_FBRD   = (UART0_BASE + 0x28);
+    UART0_LCRH   = (UART0_BASE + 0x2C);
+    UART0_CR     = (UART0_BASE + 0x30);
+    UART0_IFLS   = (UART0_BASE + 0x34);
+    UART0_IMSC   = (UART0_BASE + 0x38);
+    UART0_RIS    = (UART0_BASE + 0x3C);
+    UART0_MIS    = (UART0_BASE + 0x40),
+    UART0_ICR    = (UART0_BASE + 0x44);
+    UART0_DMACR  = (UART0_BASE + 0x48);
+    UART0_ITCR   = (UART0_BASE + 0x80);
+    UART0_ITIP   = (UART0_BASE + 0x84);
+    UART0_ITOP   = (UART0_BASE + 0x88);
+    UART0_TDR    = (UART0_BASE + 0x8C);
+
 	unsigned int selector;
 	selector = get32(GPFSEL1);
 	selector &= ~(7<<12);                   // clean gpio14
@@ -52,4 +94,3 @@ void uart_send_string(const char* str)
 		uart_send((char) str[i]);
 	}
 }
-

--- a/src/peripherals/uart.h
+++ b/src/peripherals/uart.h
@@ -3,45 +3,36 @@
 #include <stddef.h>
 #include <stdint.h>
 
-enum {
-	// The GPIO registers base address.
-	//GPIO_BASE		= 0x20200000,   // raspi1
-#if defined (raspi3)
-	GPIO_BASE		= 0x3f200000,   // raspi2 & 3
-#elif defined (raspi4)
-	GPIO_BASE		= 0xFE200000,   // raspi4
-#else // default to raspi4
-	GPIO_BASE		= 0xFE200000,
-#endif
+// The GPIO registers base address.
+unsigned int	GPIO_BASE;
 
-	// GPIO
-	GPFSEL1		= (GPIO_BASE + 0x04),
-	GPSET0		= (GPIO_BASE + 0x1C),
-	GPCLR0		= (GPIO_BASE + 0x28),
-	GPPUD		= (GPIO_BASE + 0x94),
-	GPPUDCLK0	= (GPIO_BASE + 0x98),
+// GPIO
+unsigned int	GPFSEL1;
+unsigned int	GPSET0;
+unsigned int	GPCLR0;
+unsigned int	GPPUD;
+unsigned int	GPPUDCLK0;
 
-	// The base address for UART.
-	UART0_BASE   = (GPIO_BASE + 0x1000),
-	UART0_DR     = (UART0_BASE + 0x00),
-    UART0_RSRECR = (UART0_BASE + 0x04),
-    UART0_FR     = (UART0_BASE + 0x18),
-    UART0_ILPR   = (UART0_BASE + 0x20),
-    UART0_IBRD   = (UART0_BASE + 0x24),
-    UART0_FBRD   = (UART0_BASE + 0x28),
-    UART0_LCRH   = (UART0_BASE + 0x2C),
-    UART0_CR     = (UART0_BASE + 0x30),
-    UART0_IFLS   = (UART0_BASE + 0x34),
-    UART0_IMSC   = (UART0_BASE + 0x38),
-    UART0_RIS    = (UART0_BASE + 0x3C),
-    UART0_MIS    = (UART0_BASE + 0x40),
-    UART0_ICR    = (UART0_BASE + 0x44),
-    UART0_DMACR  = (UART0_BASE + 0x48),
-    UART0_ITCR   = (UART0_BASE + 0x80),
-    UART0_ITIP   = (UART0_BASE + 0x84),
-    UART0_ITOP   = (UART0_BASE + 0x88),
-    UART0_TDR    = (UART0_BASE + 0x8C),
-};
+// The base address for UART.
+unsigned int	UART0_BASE;
+unsigned int	UART0_DR;
+unsigned int    UART0_RSRECR;
+unsigned int    UART0_FR;
+unsigned int    UART0_ILPR;
+unsigned int    UART0_IBRD;
+unsigned int    UART0_FBRD;
+unsigned int    UART0_LCRH;
+unsigned int    UART0_CR;
+unsigned int    UART0_IFLS;
+unsigned int    UART0_IMSC;
+unsigned int    UART0_RIS;
+unsigned int    UART0_MIS;
+unsigned int    UART0_ICR;
+unsigned int    UART0_DMACR;
+unsigned int    UART0_ITCR;
+unsigned int    UART0_ITIP;
+unsigned int    UART0_ITOP;
+unsigned int    UART0_TDR;
 
 void uart_init();
 


### PR DESCRIPTION
We can detect the raspi version at runtime and set the needed values during UART init instead of at compile time so let's do that!