### PR TITLE
fix S_FRAME_SIZE too small

### DIFF
--- a/include/kernel/entry.h
+++ b/include/kernel/entry.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define S_FRAME_SIZE			256 		// size of all saved registers
+#define S_FRAME_SIZE			272 		// size of all saved registers
 #define S_X0					0			// offset of x0 register in saved stack frame
 
 #define SYNC_INVALID_EL1t		0


### PR DESCRIPTION
When allocating space to save registers, ensure you allocate enough.